### PR TITLE
Refresh Windows contributor guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,82 +1,121 @@
 # Rive Runtime Windows Contributor Guide
 
-This guide documents the Windows-specific parts of the C++ runtime that
-contributors interact with, including repository entry points, setup steps,
-build workflows, and testing or sample runners.
+This guide captures Windows-specific entry points, tooling, and workflows for
+the C++ runtime. It focuses on the officially supported scripts and project
+layout in this repository.
+
+## Renderer and project layout
+- `renderer/README.md` documents how to build and run the reference desktop
+  sample (`path_fiddle`) with the Rive Renderer, the native GPU renderer that is
+  bundled with this repository.【F:renderer/README.md†L1-L23】
+- `renderer/premake5_pls_renderer.lua` defines the projects and shader build
+  steps for `rive_pls_renderer`, the default renderer library used by desktop
+  samples and platform integrations.【F:renderer/premake5_pls_renderer.lua†L1-L129】【F:renderer/premake5_pls_renderer.lua†L191-L232】
+- `premake5_v2.lua` configures the core `rive` static library along with feature
+  toggles for text, layout, audio, scripting, and tooling so the generated
+  solutions share a consistent interface across platforms.【F:premake5_v2.lua†L1-L113】
+- Public headers under `include/rive`—for example, `renderer.hpp`—expose the
+  renderer, animation, and math APIs that Windows clients link against.【F:include/rive/renderer.hpp†L5-L155】
+- Runtime implementation sources in `src/` provide the artboard loading and
+  animation plumbing that Windows hosts exercise via the generated Visual Studio
+  solutions.【F:src/file.cpp†L1-L159】
 
 ## Windows prerequisites
-- Install Visual Studio 2022 with the Desktop development with C++ workload so
-the build scripts can call the Developer Command Prompt/PowerShell shortcuts
-and access the Direct3D compiler (`fxc`).【F:build/setup_windows_dev.bat†L1-L18】【F:build/setup_windows_dev.ps1†L1-L23】
-- Install Git for Windows (Git Bash) so the batch/PowerShell wrappers can invoke
-`sh build_rive.sh` and other POSIX shell scripts without manual environment
-setup.【F:build/build_rive.bat†L1-L8】【F:build/build_rive.ps1†L1-L11】
-- Ensure CMake is available (bundled with Visual Studio 2022) before building
-the bundled GLFW dependency used by the Windows samples.【F:skia/dependencies/make_glfw.sh†L1-L25】
-
-## Key directories and entry points
-- `premake5_v2.lua` defines feature toggles (text, layout, scripting, audio) and
-applies the Windows static-library configuration for the core `rive` target that
-Visual Studio solutions consume.【F:premake5_v2.lua†L3-L164】
-- Public headers in `include/rive`, such as the renderer interface in
-`renderer.hpp`, expose the rendering, math, and animation APIs that Windows
-clients link against.【F:include/rive/renderer.hpp†L5-L155】
-- Runtime implementation sources under `src/` import `.riv` files, instantiate
-artboards/state machines, and surface data-binding helpers consumed by Windows
-apps.【F:src/file.cpp†L1-L159】
-- The Direct3D backends live in `renderer/include/rive/renderer/d3d11` and
-`renderer/include/rive/renderer/d3d12`, detailing render-target ownership,
-pipeline state, and resource helpers for Windows GPU workloads.【F:renderer/include/rive/renderer/d3d11/render_context_d3d_impl.hpp†L5-L170】【F:renderer/include/rive/renderer/d3d12/render_context_d3d12_impl.hpp†L5-L160】
-- `renderer/premake5.lua` wires Windows samples (for example, `path_fiddle`) to
-GLFW, Direct3D libraries, and optional Skia/Dawn integrations while enabling the
-runtime feature toggles selected during generation.【F:renderer/premake5.lua†L1-L176】
-- The shared `TestingWindow` abstraction in `tests/common/testing_window.hpp`
-exposes Direct3D 11/12 backends plus utility hooks for Windows-focused renderer
-and sample tests.【F:tests/common/testing_window.hpp†L5-L199】
-- Sample runners like `tests/player/player.cpp` demonstrate how Windows targets
-obtain a `TestingWindow`, load `.riv` files, and drive animation update loops for
-manual validation.【F:tests/player/player.cpp†L5-L190】
+- Install Visual Studio 2022 so the scripts can launch the Developer Command
+  Prompt (`VsDevCmd`) and access Windows tooling such as `fxc` and
+  `msbuild.exe`. The setup scripts search the default Enterprise and Community
+  install locations when Direct3D tools are missing.【F:build/setup_windows_dev.bat†L1-L18】【F:build/setup_windows_dev.ps1†L1-L23】
+- Install Git for Windows (or another POSIX-compatible shell) so the batch and
+  PowerShell wrappers can invoke `sh build_rive.sh` without manual environment
+  configuration.【F:build/build_rive.bat†L1-L9】【F:build/build_rive.ps1†L1-L11】
+- Ensure the Clang toolchain is available. The build scripts default the
+  Windows toolset to `clang`, and apply Clang-specific warning filters when the
+  toolset is not overridden.【F:build/rive_build_config.lua†L41-L58】【F:build/rive_build_config.lua†L300-L335】
 
 ## Environment initialization
-- Run `build\setup_windows_dev.bat` from `cmd.exe` to append the repository
-build scripts to `PATH`, set `RIVE_ROOT`, and launch the Visual Studio 2022
-Developer Command Prompt automatically when `fxc` is missing.【F:build/setup_windows_dev.bat†L1-L18】
-- The PowerShell variant `build\setup_windows_dev.ps1` performs the same setup,
-including automatically importing the Visual Studio 2022 developer shell before
-restoring the original working directory.【F:build/setup_windows_dev.ps1†L1-L23】
+- `build/setup_windows_dev.bat` appends the repository build scripts to `PATH`,
+  sets `RIVE_ROOT`, and launches the Visual Studio 2022 developer environment if
+  `fxc` is not already available in the shell.【F:build/setup_windows_dev.bat†L1-L18】
+- `build/setup_windows_dev.ps1` performs the same initialization in
+  PowerShell, using `Launch-VsDevShell.ps1` when the Direct3D compiler is
+  absent.【F:build/setup_windows_dev.ps1†L1-L23】
 
 ## Building on Windows
 - Use `build\build_rive.bat` (cmd) or `build\build_rive.ps1` (PowerShell) to
-initialize the environment and forward arguments to the shared
-`build_rive.sh` driver running inside Git Bash.【F:build/build_rive.bat†L1-L8】【F:build/build_rive.ps1†L1-L11】
-- `build/build_rive.sh` defaults the generator to Visual Studio 2022 on Windows,
-threads feature flags and platform arguments into Premake, and writes the final
-argument list to `out/<config>/.rive_premake_args` so incremental runs can detect
-mismatched options.【F:build/build_rive.sh†L200-L217】【F:build/build_rive.sh†L283-L293】
-- The script bootstraps Premake (including the Windows Bootstrap batch path) and
-caches helper repositories under `build/dependencies`, ensuring consistent tool
-usage across invocations.【F:build/build_rive.sh†L222-L278】
-- After project generation the script dispatches to `msbuild.exe` for
-Visual Studio solutions, optionally targeting specific projects that you pass on
-the command line (for example, `unit_tests`).【F:build/build_rive.sh†L304-L337】
+  enter the configured environment and forward arguments to the shared
+  `build_rive.sh` driver.【F:build/build_rive.bat†L1-L9】【F:build/build_rive.ps1†L1-L11】
+- `build/build_rive.sh` selects the Visual Studio 2022 generator on Windows,
+  records the Premake arguments under `out/<config>/.rive_premake_args`, builds
+  or reuses dependencies under `build/dependencies`, and finally drives
+  `msbuild.exe` against the generated solution. It also enforces argument
+  consistency so incremental builds warn when options change.【F:build/build_rive.sh†L186-L246】【F:build/build_rive.sh†L266-L341】
+- The generated Windows samples (for example, `path_fiddle`) link against
+  Direct3D, OpenGL, and GLFW through `renderer/premake5.lua`, which also exposes
+  optional integrations such as WebGPU Dawn or Skia via command-line
+  toggles.【F:renderer/premake5.lua†L1-L108】【F:renderer/premake5.lua†L109-L188】
 
 ## Running Windows tests and samples
-- Execute `tests\unit_tests\test.bat` to set up the Visual Studio environment
-(if necessary) and forward arguments to the shared `test.sh` runner.【F:tests/unit_tests/test.bat†L1-L9】
-- On Windows, `tests/unit_tests/test.sh` selects the default clang-cl toolset,
-invokes `build_rive.sh` with runtime tooling/audio/scripting options, and then
-runs the produced `unit_tests` binary from the generated output directory.【F:tests/unit_tests/test.sh†L4-L123】
-- Before launching renderer samples such as `path_fiddle`, build the GLFW
-Release libraries once via `skia/dependencies/make_glfw.sh` so the Windows
-projects can link against the expected static artifacts.【F:skia/dependencies/make_glfw.sh†L12-L25】【F:renderer/premake5.lua†L85-L103】
-- Interactive samples rely on `TestingWindow`, so they inherit the same backend
-selection and render-loop helpers described above when validating Direct3D
-behavior manually.【F:tests/common/testing_window.hpp†L37-L199】【F:tests/player/player.cpp†L143-L190】
+- `tests\unit_tests\test.bat` sets up the Visual Studio environment (when
+  required) and forwards all options to `tests/unit_tests/test.sh`.【F:tests/unit_tests/test.bat†L1-L9】
+- `tests/unit_tests/test.sh` enables Windows defaults like the `clang` toolset,
+  invokes `build_rive.sh` with the runtime feature flags needed for unit tests,
+  and then runs the resulting binary from the generated output directory.【F:tests/unit_tests/test.sh†L1-L83】【F:tests/unit_tests/test.sh†L96-L127】
+- Desktop samples such as `path_fiddle` use `TestingWindow` to create Direct3D,
+  OpenGL, or other renderer backends. The helper lives in
+  `tests/common/testing_window.hpp` with platform-specific implementations under
+  `tests/common/`.【F:tests/common/testing_window.hpp†L1-L120】【F:tests/common/testing_window.hpp†L210-L290】
 
-## Troubleshooting tips
-- If you see a Premake argument mismatch error, run the build again with the
-`clean` argument (for example, `build_rive.bat clean debug`) to remove the stale
-output directory before regenerating solutions.【F:build/build_rive.sh†L217-L289】
-- Missing Direct3D dependencies typically indicate the Visual Studio developer
-shell was not loaded; re-run the appropriate `setup_windows_dev` script so
-`fxc`, `msbuild.exe`, and associated SDK headers are on `PATH`.【F:build/setup_windows_dev.bat†L1-L18】【F:build/setup_windows_dev.ps1†L1-L23】
+## Optional renderer integrations
+- The Rive Renderer (`rive_pls_renderer`) is included by default. To experiment
+  with alternative renderers, pass the relevant Premake toggles. For example,
+  `--with-skia` pulls in the Skia renderer support files and libraries, while
+  `--with-dawn` and `--with-webgpu` enable WebGPU variants.【F:renderer/premake5.lua†L1-L89】【F:renderer/premake5.lua†L90-L156】
+- Shader assets for the Rive Renderer are compiled ahead of time by the Premake
+  logic in `renderer/premake5_pls_renderer.lua`, which builds Direct3D and SPIR-V
+  outputs on Windows when the associated options are present.【F:renderer/premake5_pls_renderer.lua†L63-L129】【F:renderer/premake5_pls_renderer.lua†L129-L189】
+
+## Community-reported Windows 11 build notes *(unconfirmed)*
+The following reports are community sourced and have not been verified by the
+core maintainers. Treat them as hypotheses to try when diagnosing local issues.
+
+### Suggested environment setup *(unconfirmed)*
+- Some contributors install additional Visual Studio workloads (such as .NET
+  desktop development or Game development with Unity) alongside Desktop
+  development with C++ to ensure optional tools are present.
+- Git Bash is used to launch `cmd.exe`, then `build\setup_windows_dev.bat`, so
+  Visual Studio tooling and Unix-style commands can co-exist in the same shell.
+- PATH tweaks may be necessary for `msbuild.exe` or GNU Make when the default
+  installation paths differ from the scripts’ expectations.
+- Installing the Clang/LLVM toolchain for MSVC (`clang-cl`) has resolved toolset
+  selection issues for some setups.
+
+### Workflow reported to succeed *(unconfirmed)*
+1. Open the repository inside Git Bash.
+2. Launch `cmd.exe` from Git Bash, then run `build\setup_windows_dev.bat` to
+   enter a Visual Studio 2022 Developer Command Prompt that still exposes
+   Unix-like commands.
+3. Invoke `build_rive.bat rebuild out/release` (sometimes from the `renderer`
+   directory) instead of building from the Visual Studio IDE to avoid shell
+   incompatibilities.
+4. Inspect generated artifacts under `renderer/out/release/`, including
+   `path-fiddle.exe` and `rive.sln`.
+
+### Community workarounds *(unconfirmed)*
+- Adjusting `renderer/src/shaders/Makefile` so `fxc` invocations quote Windows
+  paths or point to the desired Make binary has unblocked shader compilation in
+  some environments.
+- Adding `require("rive_build_config")` to `premake5.lua`, manually invoking
+  `dependencies/premake-core/bin/release/premake5.exe`, and editing generated
+  Visual Studio projects to remove unsupported flags (for example,
+  `Wno-atomic-alignment`) have helped contributors who run into Premake or
+  project configuration errors.
+- Installing GNU Make, exposing `msbuild.exe` on `PATH`, or toggling Release
+  preprocessor definitions inside Visual Studio have been cited as necessary for
+  certain configurations.
+
+### Additional observations *(unconfirmed)*
+- The `yup` repository (https://github.com/kunitoki/yup) offers a CMake-based
+  integration of the Rive renderer that some contributors use as a reference.
+- Updating Direct3D 12 upload-heap resource states to
+  `D3D12_RESOURCE_STATE_GENERIC_READ` resolved initialization failures on
+  enterprise NVIDIA drivers for one community member.


### PR DESCRIPTION
## Summary
- align the Windows contributor guide with the current Rive renderer workflow and official scripts
- clarify prerequisites, build steps, and optional renderer toggles based on the maintained build system
- retain the community-sourced notes while clearly marking them as unverified tips

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e28d687bd88329b6f66d40dd5ba6ab